### PR TITLE
Issue #000 fix: Card badge avatar alignment issue

### DIFF
--- a/src/app/client/src/app/modules/shared/components/card/card.component.scss
+++ b/src/app/client/src/app/modules/shared/components/card/card.component.scss
@@ -42,6 +42,7 @@
         justify-content: flex-end;
         height: 92px;
         overflow: hidden;
+        width: calc(100% - 70px);
     }
     .avatar{
         height: 31px;


### PR DESCRIPTION
**Before - Badge misaligned if data not available**

![card-badge-before](https://user-images.githubusercontent.com/30073416/48697062-a7ddec80-ec09-11e8-8e3d-1cc587fddc65.png)

**After - Badge aligned if data not available**
![card-badge-after](https://user-images.githubusercontent.com/30073416/48697071-b62c0880-ec09-11e8-8366-a9ecdc22390d.png)
